### PR TITLE
Target ES2017

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2017",
     "module": "commonjs",
     "declaration": true,
     "outDir": "./lib",


### PR DESCRIPTION
Node.js versions 8 to 14 has 100% compatibility with the ES2017 spec so we shouldn't need to target ES5 anymore. 🎉 

@cbschuld Any issues with bumping this on your end?