### PR TITLE
adding decimal support

### DIFF
--- a/src/RDSData.ts
+++ b/src/RDSData.ts
@@ -22,7 +22,7 @@ export interface RDSDataType {
     [x: string]: string | boolean | Buffer | null;
   };
 }
-export type RDSDataTypes = 'stringValue' | 'booleanValue' | 'longValue' | 'isNull' | 'blobValue' | undefined;
+export type RDSDataTypes = 'stringValue' | 'booleanValue' | 'longValue' | 'isNull' | 'blobValue' | 'doubleValue' |undefined;
 
 export type RDSDataParameterValue = string | Buffer | boolean | number | null | undefined;
 export interface RDSDataParameters {
@@ -122,6 +122,9 @@ export class RDSData {
         return 'booleanValue';
       }
       if (t === 'number') {
+        if (val && val as number % 1 !== 0) {
+          return 'doubleValue';
+        }
         return 'longValue';
       }
       if (val === null) {

--- a/src/RDSData.ts
+++ b/src/RDSData.ts
@@ -213,6 +213,9 @@ export class RDSData {
             case 'SERIAL':
               v.number = isNull ? undefined : record[c].longValue;
               break;
+            case 'DECIMAL':
+              v.number = isNull ? undefined : parseFloat(record[c].stringValue!);
+              break;
             case 'UUID':
             case 'TEXT':
             case 'CHAR':


### PR DESCRIPTION
Change adds decimal support. Response for a decimal column from the AWS SDK is the following. Decimal columns are returned with a "stringValue" property.

`
{
	"columnMetadata": [{
			"arrayBaseColumnType": 0,
			"isAutoIncrement": false,
			"isCaseSensitive": false,
			"isCurrency": false,
			"isSigned": false,
			"label": "account",
			"name": "account",
			"nullable": 0,
			"precision": 100,
			"scale": 0,
			"schemaName": "",
			"tableName": "Movements",
			"type": 12,
			"typeName": "VARCHAR"
		},
		{
			"arrayBaseColumnType": 0,
			"isAutoIncrement": false,
			"isCaseSensitive": true,
			"isCurrency": false,
			"isSigned": true,
			"label": "functional_amount",
			"name": "functional_amount",
			"nullable": 0,
			"precision": 27,
			"scale": 8,
			"schemaName": "",
			"tableName": "Movements",
			"type": 3,
			"typeName": "DECIMAL"
		},
		{
			"arrayBaseColumnType": 0,
			"isAutoIncrement": false,
			"isCaseSensitive": true,
			"isCurrency": false,
			"isSigned": true,
			"label": "transaction_amount",
			"name": "transaction_amount",
			"nullable": 0,
			"precision": 27,
			"scale": 8,
			"schemaName": "",
			"tableName": "Movements",
			"type": 3,
			"typeName": "DECIMAL"
		}
	],
	"numberOfRecordsUpdated": 0,
	"records": [
		[{
				"stringValue": "account"
			},
			{
				"stringValue": "100.00000000"
			},
			{
				"stringValue": "100.00000000"
			}
		]
	]
}
`